### PR TITLE
fix(loop): replace CronCreate with PID-based loop + atomic ticket claim

### DIFF
--- a/agents/positions/chief-builder/personas/dev.md
+++ b/agents/positions/chief-builder/personas/dev.md
@@ -369,21 +369,41 @@ Three modes — detect in this order:
 
 **Mode B — resume-crash** : `LAST_MILESTONE` is non-empty AND `EXISTING_BRANCH` found AND no "PR ready:" comment exists.
 
-```
+```bash
 → RESUME MODE
-  Log: _log "$RUN_ID" "dev" "$TICKET_N" "resume" "ok" \
-         "resuming from remote branch" "{\"branch\":\"$EXISTING_BRANCH\"}"
+
+# Verify the branch actually exists on remote before committing to resume
+git fetch origin 2>/dev/null
+BRANCH_EXISTS=$(git ls-remote --heads origin "$EXISTING_BRANCH" | grep -c "$EXISTING_BRANCH" || true)
+
+if [ "$BRANCH_EXISTS" -eq 0 ]; then
+  # Milestone exists but branch is gone — comment and fall back to Mode C
+  LAST_MILESTONE_EXCERPT=$(echo "$LAST_MILESTONE" | head -5)
+  gh issue comment "$TICKET_N" --repo "$OWNER/$REPO" \
+    --body "⚠️ **Resume attempted** — branch \`${EXISTING_BRANCH}\` not found on remote.
+Restarting fresh. Previous milestone context:
+\`\`\`
+${LAST_MILESTONE_EXCERPT}
+\`\`\`"
+  _log "$RUN_ID" "dev" "$TICKET_N" "resume_fallback" "warning" \
+    "branch not found on remote — falling back to fresh start" \
+    "{\"missing_branch\":\"$EXISTING_BRANCH\"}"
+  # Fall through to Mode C below
+else
+  _log "$RUN_ID" "dev" "$TICKET_N" "resume" "ok" \
+    "resuming from remote branch" "{\"branch\":\"$EXISTING_BRANCH\"}"
 
   1. Read LAST_MILESTONE content — extract "Phase:" and "Next:" lines
   2. git checkout -b "$EXISTING_BRANCH" --track "origin/$EXISTING_BRANCH"
-  3. Skip step 2 (branch creation) — branch already exists on remote
+  3. Skip step 2 (branch creation + claim push) — branch already on remote = claim already held
   4. Continue from the "Next:" line of LAST_MILESTONE
 
   Note: any uncommitted work from the previous session is lost (different machine
   principle). The "Next:" line in the milestone is the recovery anchor.
+fi
 ```
 
-**Mode C — fresh start** : no milestones, no remote branch → continue normally from step 2.
+**Mode C — fresh start** : no milestones, no remote branch (or Mode B fallback) → continue normally from step 2.
 
 ```bash
 _log "$RUN_ID" "dev" "$TICKET_N" "context_loaded" "ok" \
@@ -418,21 +438,45 @@ _log "$RUN_ID" "dev" "$TICKET_N" "plan_validated" "ok" \
   "plan validated against codebase" "{\"valid\":$PLAN_VALID}"
 ```
 
-### 2. Create the feature branch
+### 2. Claim the ticket (branch + remote push)
+
+`short-name` = 2-4 words from the ticket title, kebab-case.
+
+**Mode C (fresh start) only** — Mode A and Mode B skip this step entirely.
 
 ```bash
 git checkout dev
 git pull origin dev
-git checkout -b feat/ticket-<N>-<short-name>
-```
+git checkout -b "feat/ticket-${TICKET_N}-${SHORT_NAME}"
 
-`short-name` = 2-4 words from the ticket title, kebab-case.
+_init_lock_metadata  # write .lock + start heartbeat &
 
-```bash
-_log "$RUN_ID" "dev" "$TICKET_N" "branch_created" "ok" \
-  "branch created" "{\"branch\":\"feat/ticket-${TICKET_N}-${SHORT_NAME}\"}"
+# Push an empty commit immediately — this is the atomic ownership test.
+# If rejected, another agent already holds this branch → release the claim.
+git commit --allow-empty \
+  -m "chore: claim ticket #${TICKET_N} — $(date -u +%Y-%m-%dT%H:%MZ)"
 
-_init_lock_metadata  # register PID + start times in lock file
+git push origin "feat/ticket-${TICKET_N}-${SHORT_NAME}"
+PUSH_EXIT=$?
+
+if [ $PUSH_EXIT -ne 0 ]; then
+  _log "$RUN_ID" "dev" "$TICKET_N" "claim_lost" "error" \
+    "push rejected — branch already exists on remote" "{}"
+
+  gh issue comment "$TICKET_N" --repo "$OWNER/$REPO" \
+    --body "⚠️ **Claim lost** — branch \`feat/ticket-${TICKET_N}-${SHORT_NAME}\` already exists on remote.
+Releasing ticket back to queue."
+
+  kill "$_HEARTBEAT_PID" 2>/dev/null || true
+  rm -f "${_LOCK_FILE}"
+  gh issue edit "$TICKET_N" --repo "$OWNER/$REPO" \
+    --remove-label "dev-in-progress" --add-label "to-dev"
+  exit 0
+fi
+
+_log "$RUN_ID" "dev" "$TICKET_N" "claim_established" "ok" \
+  "branch pushed — claim complete" \
+  "{\"branch\":\"feat/ticket-${TICKET_N}-${SHORT_NAME}\"}"
 ```
 
 ### 3. Implement

--- a/lib/ghost_buster.py
+++ b/lib/ghost_buster.py
@@ -241,10 +241,65 @@ def _cleanup_ghost(
     )
 
 
+# ── Loop ghost detection ──────────────────────────────────────────────────────
+
+def bust_ghost_loops(locks_dir: Path, dry_run: bool = False) -> int:
+    """Detect and clean up loop-*.json files whose PID is dead.
+
+    Returns count of ghost loops cleaned (or detected if dry_run).
+    If current_ticket is set, the associated ticket agent is handled
+    independently by the normal ghost detection flow.
+    """
+    if not locks_dir.exists():
+        return 0
+
+    prefix = "[DRY RUN] " if dry_run else ""
+    cleaned = 0
+
+    for f in sorted(locks_dir.glob("loop-*.json")):
+        try:
+            data = json.loads(f.read_text())
+        except (json.JSONDecodeError, OSError):
+            if not dry_run:
+                f.unlink(missing_ok=True)
+            cleaned += 1
+            continue
+
+        pid = data.get("pid")
+        if not pid:
+            if not dry_run:
+                f.unlink(missing_ok=True)
+            cleaned += 1
+            continue
+
+        if _pid_alive(pid):
+            continue  # loop still running — do not touch
+
+        role = data.get("role", "unknown")
+        current_ticket = data.get("current_ticket")
+        print(f"{prefix}👻 Ghost loop: {f.name} (role={role}, pid={pid})")
+        if current_ticket:
+            print(f"   Was waiting for ticket #{current_ticket}"
+                  f" — handled by normal ticket ghost detection")
+
+        if not dry_run:
+            f.unlink(missing_ok=True)
+            stop = f.with_name(f.stem + ".stop")
+            stop.unlink(missing_ok=True)
+            print(f"   ✅ Loop ghost cleaned")
+
+        cleaned += 1
+
+    return cleaned
+
+
 # ── Main entry ────────────────────────────────────────────────────────────────
 
 def run(locks_dir: Path, owner: str, repo: str, dry_run: bool = False) -> int:
     """Run ghost buster. Returns number of ghosts cleaned (or detected if dry_run)."""
+    # Clean up dead loop processes first (before ticket agent detection)
+    loop_ghosts = bust_ghost_loops(locks_dir, dry_run)
+
     local_ghosts  = bust_local_ghosts(locks_dir, owner, repo, dry_run)
     remote_ghosts = bust_remote_ghosts(owner, repo, dry_run)
 
@@ -255,7 +310,7 @@ def run(locks_dir: Path, owner: str, repo: str, dry_run: bool = False) -> int:
 
     prefix = "[DRY RUN] " if dry_run else ""
     if all_ghosts:
-        print(f"\n{prefix}👻 Ghost buster — {len(all_ghosts)} ghost(s) detected:")
+        print(f"\n{prefix}👻 Ghost buster — {len(all_ghosts)} agent ghost(s) detected:")
         for g in all_ghosts:
             src = g["source"]
             print(
@@ -263,10 +318,10 @@ def run(locks_dir: Path, owner: str, repo: str, dry_run: bool = False) -> int:
                 f"  {g['reason']}  [{src}]"
             )
         print()
-    else:
+    elif loop_ghosts == 0:
         print(f"{prefix}👻 Ghost buster — no ghosts detected.")
 
-    return len(all_ghosts)
+    return len(all_ghosts) + loop_ghosts
 
 
 if __name__ == "__main__":

--- a/skills/cao-cancel-loop/SKILL.md
+++ b/skills/cao-cancel-loop/SKILL.md
@@ -2,30 +2,58 @@
 name: cao-cancel-loop
 description: |
   Cancel an active cao-process-tickets loop.
-  Deletes the CronCreate task(s) created by /cao-process-tickets --loop.
+  Writes a stop signal file that the loop detects at the start of its next iteration,
+  after the current ticket finishes. Graceful — never interrupts a running agent.
 argument-hint: "[chief-builder|dev|all]"
 allowed-tools: [Bash]
 ---
 
 # /cao-cancel-loop — Cancel an active loop
 
-Stops the scheduled polling started by `/cao-process-tickets --loop`.
+Stops the loop polling started by `/cao-process-tickets --loop`.
+Graceful: the current ticket always finishes before the loop exits.
 
 ## What it does
 
-Parse `$ARGUMENTS` to determine which cron to cancel:
-- No argument or `all` → cancel all `cao-process-*` crons
-- `chief-builder` → cancel `cao-process-chief-builder`
-- `dev` → cancel `cao-process-dev`
+Parse `$ARGUMENTS`:
+- No argument or `all` → match all `loop-*.json` files
+- `chief-builder`       → match `loop-chief-builder-*.json`
+- `dev`                 → match `loop-dev-*.json`
 
-Use `CronDelete` to remove the matching task(s), then confirm:
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+LOCKS="${REPO_ROOT}/.locks"
 
-```
-✅ Loop cancelled: cao-process-{ROLE}
-   Run /cao-process-tickets [role] --loop to restart.
-```
+# Determine glob pattern
+case "${ARGUMENTS:-all}" in
+  chief-builder) PATTERN="loop-chief-builder-*.json" ;;
+  dev)           PATTERN="loop-dev-*.json" ;;
+  *)             PATTERN="loop-*.json" ;;
+esac
 
-If no matching cron found:
-```
-ℹ️  No active cao loop found for role: {ROLE}
+FOUND=0
+for f in ${LOCKS}/${PATTERN}; do
+  [ -f "$f" ] || continue
+  FOUND=1
+
+  PID=$(python3 -c "import json; print(json.load(open('$f'))['pid'])" 2>/dev/null)
+  ROLE=$(python3 -c "import json; print(json.load(open('$f'))['role'])" 2>/dev/null)
+
+  # Verify PID is alive
+  if ! kill -0 "$PID" 2>/dev/null; then
+    echo "⚠️  Loop pid $PID is already dead — cleaning up"
+    rm -f "$f"
+    continue
+  fi
+
+  # Write stop signal (same name, .stop extension)
+  STOP="${f%.json}.stop"
+  touch "$STOP"
+  echo "✅ Stop signal sent to loop ${ROLE} (pid: ${PID})"
+  echo "   The loop will stop after the current ticket finishes."
+done
+
+if [ "$FOUND" -eq 0 ]; then
+  echo "ℹ️  No active cao loop found for role: ${ARGUMENTS:-all}"
+fi
 ```

--- a/skills/cao-process-tickets/SKILL.md
+++ b/skills/cao-process-tickets/SKILL.md
@@ -203,47 +203,82 @@ Always output a brief summary:
 
 ### Loop scheduling — drain then sleep
 
-If LOOP = true, apply the **drain then sleep** logic:
+If LOOP = true, apply the **drain then sleep** logic.
 
+**Startup (once, before the first iteration):**
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+LOOP_PID=$$
+LOOP_FILE="${REPO_ROOT}/.locks/loop-${ROLE}-${LOOP_PID}.json"
+STOP_FILE="${REPO_ROOT}/.locks/loop-${ROLE}-${LOOP_PID}.stop"
+
+python3 - <<PYEOF
+import json, time
+from pathlib import Path
+Path("${REPO_ROOT}/.locks").mkdir(exist_ok=True)
+Path("${LOOP_FILE}").write_text(json.dumps({
+    "pid": ${LOOP_PID},
+    "role": "${ROLE}",
+    "interval": ${INTERVAL},
+    "started_at": time.time(),
+    "last_heartbeat_ts": time.time(),
+    "current_ticket": None,
+    "state": "idle"
+}, indent=2))
+PYEOF
+```
+
+**Start of each iteration:**
+
+1. Update `last_heartbeat_ts` in `$LOOP_FILE`
+2. Check if `$STOP_FILE` exists:
+```bash
+if [ -f "$STOP_FILE" ]; then
+  rm -f "$LOOP_FILE" "$STOP_FILE"
+  echo "🛑 Loop stopped gracefully (role: ${ROLE}, pid: ${LOOP_PID})"
+  exit 0
+fi
+```
+
+**Before spawning an agent** — update `$LOOP_FILE`:
+```python
+{ "current_ticket": N, "state": "waiting_agent" }
+```
+
+**Drain-then-sleep logic:**
 ```
 ANY_PROCESSED = (at least one ticket was processed in this run)
 
 If ANY_PROCESSED = true:
-  → Re-launch immediately with no delay
-  → CronCreate(
-      taskId: "cao-process-{ROLE}",
-      cronExpression: "* * * * *",     ← every minute (immediate in cron terms)
-      prompt: "/cao-process-tickets {ROLE} --loop --interval {INTERVAL}"
-    )
+  → update LOOP_FILE: { "current_ticket": null, "state": "idle" }
+  → loop immediately (no sleep)
   → Output: "🔁 Ticket processed — immediate re-poll"
 
 If ANY_PROCESSED = false (queue empty):
-  → Sleep INTERVAL minutes
-  → CronCreate(
-      taskId: "cao-process-{ROLE}",
-      cronExpression: "*/{INTERVAL} * * * *",
-      prompt: "/cao-process-tickets {ROLE} --loop --interval {INTERVAL}"
-    )
+  → update LOOP_FILE: { "state": "idle" }
+  → sleep INTERVAL minutes
   → Output: "💤 Queue empty — next poll in {INTERVAL}min"
 ```
 
-**Principle**: the agent drains the queue as long as there is work, then sleeps only when it finds nothing. Zero unnecessary polls between consecutive tickets.
+**Principle**: drain the queue as long as there is work, sleep only when idle.
 
-After CronCreate:
-- If success, log:
-  ```
-  RUN_ID = current timestamp in format YYYYMMDD_HHMMSS_loop
-  Run: python3 lib/logger.py "{RUN_ID}" "worker" "null" "worker_start" "ok" "loop scheduled" '{"role":"{ROLE}","interval":{INTERVAL},"any_processed":{ANY_PROCESSED}}'
-  ```
-- If failure, log:
-  ```
-  Run: python3 lib/logger.py "{RUN_ID}" "worker" "null" "schedule_error" "error" "CronCreate failed" '{"role":"{ROLE}"}'
-  ```
-
-Then output:
+**Graceful exit (stop signal or fatal error):**
+```bash
+rm -f "$LOOP_FILE" "$STOP_FILE"
 ```
-⏱️  Next run: [immediate | in {INTERVAL}min] (cron: cao-process-{ROLE})
-   Stop with: /cancel-cao or ask Claude to delete cron "cao-process-{ROLE}"
+
+**Logging:**
+```bash
+RUN_ID=$(date -u +"%Y%m%d_%H%M%S")_loop
+python3 lib/logger.py "$RUN_ID" "worker" "null" "worker_start" "ok" "loop iteration" \
+  "{\"role\":\"${ROLE}\",\"interval\":${INTERVAL},\"any_processed\":${ANY_PROCESSED}}"
+```
+
+**Output at end of each iteration:**
+```
+⏱️  Next run: [immediate | in {INTERVAL}min] (loop pid: {LOOP_PID})
+   Stop with: /cao-cancel-loop [role]
 ```
 
 ## Example sessions
@@ -258,18 +293,18 @@ Then output:
 **Loop — multiple tickets waiting (drain):**
 ```
 /cao-process-tickets --loop
-→ 🔄 Loop mode — role: all, interval: 5min
+→ 🔄 Loop mode — role: all, interval: 5min (pid: 1234)
 
-run 1: processes #5 (to-enrich) → ✅ Processed: #5 → 🔁 immediate re-poll
-run 2: processes #3 (to-dev)    → ✅ Processed: #3 → 🔁 immediate re-poll
-run 3: processes #1 (godeploy)  → ✅ Processed: #1 → 🔁 immediate re-poll
-run 4: nothing                  → 💤 queue empty → ⏱️ next poll in 5min
+iter 1: processes #5 (to-enrich) → ✅ Processed: #5 → 🔁 immediate re-poll
+iter 2: processes #3 (to-dev)    → ✅ Processed: #3 → 🔁 immediate re-poll
+iter 3: processes #1 (godeploy)  → ✅ Processed: #1 → 🔁 immediate re-poll
+iter 4: nothing                  → 💤 queue empty → ⏱️ next poll in 5min
 ```
 
 **Loop — empty queue at startup:**
 ```
 /cao-process-tickets --loop
-→ 🔄 Loop mode — role: all, interval: 5min
+→ 🔄 Loop mode — role: all, interval: 5min (pid: 1234)
 → Nothing to process
 → 💤 queue empty — ⏱️ next poll in 5min
 ```
@@ -277,9 +312,19 @@ run 4: nothing                  → 💤 queue empty → ⏱️ next poll in 5mi
 **Loop — custom interval:**
 ```
 /cao-process-tickets dev --loop --interval 10
-→ 🔄 Loop mode — role: dev, interval: 10min
+→ 🔄 Loop mode — role: dev, interval: 10min (pid: 5678)
 → Nothing to process
 → 💤 queue empty — ⏱️ next poll in 10min
+```
+
+**Loop — graceful stop:**
+```
+[Terminal B] /cao-cancel-loop
+→ ✅ Stop signal sent to loop all (pid: 1234)
+→    The loop will stop after the current ticket finishes.
+
+[Terminal A, after current ticket done]
+→ 🛑 Loop stopped gracefully (role: all, pid: 1234)
 ```
 
 ## Implementation notes


### PR DESCRIPTION
## Summary

- **CronCreate supprimé** — chaque appel créait un nouveau job indépendant → accumulation exponentielle après N runs. Remplacé par une vraie boucle avec fichier PID JSON dans `.locks/loop-{ROLE}-{PID}.json`
- **Stop graceful multi-terminal** — `/cao-cancel-loop` écrit un fichier `.stop` ciblé par PID au lieu de `CronDelete`. Chaque terminal a sa boucle isolée.
- **Claim atomique** — le dev agent pousse un commit vide immédiatement après la création de branche. Push rejeté = claim perdu → release propre du label. Fin de la fenêtre d'incohérence entre label GitHub et branche remote.
- **Ghost buster étendu** — détecte et nettoie les `loop-*.json` orphelins (PID mort).

## Fichiers modifiés

| Fichier | Changement |
|---|---|
| `skills/cao-process-tickets/SKILL.md` | CronCreate → boucle + PID JSON |
| `skills/cao-cancel-loop/SKILL.md` | CronDelete → fichier `.stop` |
| `agents/positions/chief-builder/personas/dev.md` | Claim atomique + Mode B fallback |
| `lib/ghost_buster.py` | `bust_ghost_loops()` ajouté |

## Test plan

- [ ] `/cao-process-tickets --loop` → vérifier `.locks/loop-all-{PID}.json` créé
- [ ] `/cao-cancel-loop` → vérifier `.stop` créé, loop s'arrête après ticket en cours
- [ ] Deux terminaux avec `--loop` → deux `.json` indépendants, cancel isolé
- [ ] `/cao-cancel-loop dev` sur loop `all` → ne doit pas matcher
- [ ] Simuler crash loop (kill PID) → ghost_buster nettoie le `.json`
- [ ] Simuler push rejeté (branche créée manuellement) → agent libère le ticket proprement
- [ ] Mode B avec branche supprimée → commentaire GitHub + repart en Mode C

🤖 Generated with [Claude Code](https://claude.com/claude-code)